### PR TITLE
Fix/correct permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ We use a lot of the same environment variables that the Kubernetes git-sync cont
 * `GIT_SYNC_ONE_TIME` – Whether we should clone once and never pull again.
 * `GIT_SYNC_USERNAME` – The auth username to use.
 * `GIT_SYNC_PASSWORD` – The auth password to use.
+* `GIT_SYNC_KNOWN_HOSTS` - The known_hosts file content
 
 Plus we add a couple more.
 

--- a/rootfs/start.sh
+++ b/rootfs/start.sh
@@ -7,6 +7,11 @@ if [ -n "$GIT_SYNC_PRIVATE_KEY" ]; then
     echo "$GIT_SYNC_PRIVATE_KEY" > "$gitSecret"
 fi
 
+gitHosts="/root/.ssh/known_hosts"
+if [ -n "$GIT_SYNC_KNOWN_HOSTS" ]; then
+    echo "$GIT_SYNC_KNOWN_HOSTS" > "$gitHosts"
+fi
+
 if [ -z "$GIT_SYNC_REPO" ]; then
     echo -e "\nERROR: No git repository specified in GIT_SYNC_REPO"
     exit 1

--- a/rootfs/start.sh
+++ b/rootfs/start.sh
@@ -5,6 +5,7 @@ gitSecret="/root/.ssh/id_rsa"
 mkdir -p /root/.ssh
 if [ -n "$GIT_SYNC_PRIVATE_KEY" ]; then
     echo "$GIT_SYNC_PRIVATE_KEY" > "$gitSecret"
+    chmod 0600 "$gitSecret"
 fi
 
 gitHosts="/root/.ssh/known_hosts"


### PR DESCRIPTION
If the key is passed by the docker environment, it's got the wrong permission and the clone doesn't happen.

- How I run: docker run -e GIT_SYNC_REPO=myrepo -e GIT_SYNC_SSH=true -e GIT_SYNC_PRIVATE_KEY= 'id_rsa content'  jorgeandrada/git-sync

> 

`-----END OPENSSH PRIVATE KEY-----'
Cloning into '/git'... @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@ WARNING: UNPROTECTED PRIVATE KEY FILE! @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions 0644 for '/root/.ssh/id_rsa' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
Load key "/root/.ssh/id_rsa": bad permissions
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
`